### PR TITLE
Ignores vendored JS dependencies on CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,3 +23,4 @@ ratings:
   - "**.rb"
 exclude_paths:
 - spec/
+- source/javascripts/lib/


### PR DESCRIPTION
CodeClimate is giving us a bad score because of our vendored
dependencies, which are usually minified and "bad" code according to
development standards.

This commit start filtering the vendored files out.