### PR TITLE
Adds more can variable documentation

### DIFF
--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -7,29 +7,29 @@ Name | Description | Standard Unit
 ENGINE_HOURS | Total hours of equipment engine | Seconds
 ENGINE_SPEED | Engine speed of equipment | RPM
 DRIVE_DIRECTION | Driving direction of equipment | [Enumeration DRIVE_DIRECTION](#enumeration-drive_direction)
-ENGINE_LOAD | ??? | Percentage (%)
-FUEL_LEVEL | ??? | Percentage (%)
-FUEL_RATE | ??? | Cubic metre per seconds (m³/s)
-MASTER_APPLY | ??? | [Enumeration MASTER_APPLY](#enumeration-master_apply)
-MOISTURE_AVERAGE | ??? | Percentage (%)
-YIELD_AVERAGE | ??? | Kilograms per square metre (kg/m²)
-CAPACITY_Average | ??? | Kilograms per second (kg/s)
-TEST_WEIGHT | ??? | Kilograms per cubic metre (kg/m³)
-HARVEST_HOURS | ??? | Seconds
-RATE | ??? | ???
-UNLOAD_AUGER | ??? | [Enumeration UNLOAD_AUGER](#enumeration-unload_auger)
-BALE_WEIGHT | ??? | Kilograms
-BALE_WEIGHT_AVERAGE | ??? | Kilograms
-BALE_FLAKES_AVERAGE | ??? | ???
-COUNTER_Bale_Cut | ??? | ???
-COUNTER_Bale_Uncut | ??? | ???
-GRAIN_LOSS_Shaker | ??? | Percentage (%)
-GRAIN_LOSS_Rotor | ??? | Percentage (%)
-INDUSTRIAL_DRIVE_ENGAGE | ??? | [Enumeration INDUSTRIAL_DRIVE_ENGAGE](#enumeration-industrial_drive_engage)
-PRIMARY_EXTRACTOR_ENGAGE | ??? | [Enamuration PRIMARY_EXTRACTOR_ENGAGE](#enumeration-primary_extractor_engage)
-SIEVE_POSITION_Upper_Right | ??? | Distance in miles
-STROKE_PER_FLAKE | ??? | ???
-TOPPER_DRIVE_ENGAGE | ??? | [Enumeration TOPPER_DRIVE_ENGAGE](#enumeration-topper_drive_engage)
+ENGINE_LOAD | Percentage load on engine | Percentage (%)
+FUEL_LEVEL | Percentage of fuel tank level | Percentage (%)
+FUEL_RATE | Rate of fuel consuption | Cubic metre per seconds (m³/s)
+MASTER_APPLY | Sprayer applying product | [Enumeration MASTER_APPLY](#enumeration-master_apply)
+MOISTURE_AVERAGE | Average crop moisture in a combine | Percentage (%)
+YIELD_AVERAGE | Average yeild /area from combine | Kilograms per square metre (kg/m²)
+CAPACITY_Average | Average capacity for a combine | Kilograms per second (kg/s)
+TEST_WEIGHT | User defined test weight for a crop in a combine | Kilograms per cubic metre (kg/m³)
+HARVEST_HOURS | Hours on combine seperator | Seconds
+RATE | Rate being applied by a sprayer | Milimeters squared per second (mm²/s)
+UNLOAD_AUGER | Combine unloading auger status | [Enumeration UNLOAD_AUGER](#enumeration-unload_auger)
+BALE_WEIGHT | Weight of last bale | Kilograms
+BALE_WEIGHT_AVERAGE | Average bale weight | Kilograms
+BALE_FLAKES_AVERAGE | Average flakes per bale | Range 0 - 65635
+COUNTER_Bale_Cut | Number of cut bales with cutter engaged | Range 0 - 65635
+COUNTER_Bale_Uncut | Number of uncut bales | Range 0 - 1000
+GRAIN_LOSS_Shaker | Percentage of grain lost at shaker in a combine | Percentage (%)
+GRAIN_LOSS_Rotor | Percentage of grain lost at rotor in a combine | Percentage (%)
+INDUSTRIAL_DRIVE_ENGAGE | Sugar Cane harvester drive status | [Enumeration INDUSTRIAL_DRIVE_ENGAGE](#enumeration-industrial_drive_engage)
+PRIMARY_EXTRACTOR_ENGAGE | Sugar Cane harvester extractor status | [Enamuration PRIMARY_EXTRACTOR_ENGAGE](#enumeration-primary_extractor_engage)
+SIEVE_POSITION_Upper_Right | Combine sieve setting  | Distance in miles
+STROKE_PER_FLAKE | Strokes per flake - baler | Range 0 - 1000
+TOPPER_DRIVE_ENGAGE | Sugar Cane harvester topper drive status | [Enumeration TOPPER_DRIVE_ENGAGE](#enumeration-topper_drive_engage)
 CAPACITY | Instant combine capacity | Kilograms per second (kg/s)
 MOISTURE | ??? | Percentage (%)
 BALE_WEIGHT_Total | Total weight baled | Kilograms

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -31,7 +31,7 @@ SIEVE_POSITION_Upper_Right | Combine sieve setting  | Distance in miles
 STROKE_PER_FLAKE | Strokes per flake - baler | Range 0 - 1000
 TOPPER_DRIVE_ENGAGE | Sugar Cane harvester topper drive status | [Enumeration TOPPER_DRIVE_ENGAGE](#enumeration-topper_drive_engage)
 CAPACITY | Instant combine capacity | Kilograms per second (kg/s)
-MOISTURE | ??? | Percentage (%)
+MOISTURE | Measurement of crop moisture during harvest | Percentage (%)
 BALE_WEIGHT_Total | Total weight baled | Kilograms
 
 ## Enumeration DRIVE_DIRECTION

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -15,6 +15,9 @@ MOISTURE_AVERAGE | ??? | Percentage (%)
 YIELD_AVERAGE | ??? | Kilograms per square metre (kg/m²)
 CAPACITY_Average | ??? | Kilograms per second (kg/s)
 TEST_WEIGHT | ??? | Kilograms per cubic metre (kg/m³)
+HARVEST_HOURS | ??? | Seconds
+RATE | ??? | ???
+UNLOAD_AUGER | ??? | [Enumeration UNLOAD_AUGER](#enumeration-unload_auger)
 
 ## Enumeration DRIVE_DIRECTION
 
@@ -27,6 +30,15 @@ STAND STILL | 3
 CRUISE CONTROL | 4
 
 ## Enumeration MASTER_APPLY
+
+Name | Value
+---- | -----
+OFF | 0
+ON | 1
+ERROR | 2
+NA | 3
+
+## Enumeration UNLOAD_AUGER
 
 Name | Value
 ---- | -----

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -25,6 +25,11 @@ COUNTER_Bale_Cut | ??? | ???
 COUNTER_Bale_Uncut | ??? | ???
 GRAIN_LOSS_Shaker | ??? | Percentage (%)
 GRAIN_LOSS_Rotor | ??? | Percentage (%)
+INDUSTRIAL_DRIVE_ENGAGE | ??? | [Enumeration INDUSTRIAL_DRIVE_ENGAGE](#enumeration-industrial_drive_engage)
+PRIMARY_EXTRACTOR_ENGAGE | ??? | [Enamuration PRIMARY_EXTRACTOR_ENGAGE](#enumeration-primary_extractor_engage)
+SIEVE_POSITION_Upper_Right | ??? | Distance in miles
+STROKE_PER_FLAKE | ??? | ???
+TOPPER_DRIVE_ENGAGE | ??? | [Enumeration TOPPER_DRIVE_ENGAGE](#enumeration-topper_drive_engage)
 
 ## Enumeration DRIVE_DIRECTION
 
@@ -46,6 +51,34 @@ ERROR | 2
 NA | 3
 
 ## Enumeration UNLOAD_AUGER
+
+Name | Value
+---- | -----
+OFF | 0
+ON | 1
+ERROR | 2
+NA | 3
+
+## Enumeration INDUSTRIAL_DRIVE_ENGAGE
+
+Name | Value
+---- | -----
+OFF | 0
+ON | 1
+ERROR | 2
+NA | 3
+Reverse | 4
+
+## Enumeration PRIMARY_EXTRACTOR_ENGAGE
+
+Name | Value
+---- | -----
+OFF | 0
+ON | 1
+ERROR | 2
+NA | 3
+
+## Enumeration TOPPER_DRIVE_ENGAGE
 
 Name | Value
 ---- | -----

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -30,6 +30,9 @@ PRIMARY_EXTRACTOR_ENGAGE | ??? | [Enamuration PRIMARY_EXTRACTOR_ENGAGE](#enumera
 SIEVE_POSITION_Upper_Right | ??? | Distance in miles
 STROKE_PER_FLAKE | ??? | ???
 TOPPER_DRIVE_ENGAGE | ??? | [Enumeration TOPPER_DRIVE_ENGAGE](#enumeration-topper_drive_engage)
+CAPACITY | Instant combine capacity | Kilograms per second (kg/s)
+MOISTURE | ??? | Percentage (%)
+BALE_WEIGHT_Total | Total weight baled | Kilograms
 
 ## Enumeration DRIVE_DIRECTION
 

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -18,6 +18,11 @@ TEST_WEIGHT | ??? | Kilograms per cubic metre (kg/m³)
 HARVEST_HOURS | ??? | Seconds
 RATE | ??? | ???
 UNLOAD_AUGER | ??? | [Enumeration UNLOAD_AUGER](#enumeration-unload_auger)
+BALE_WEIGHT | ??? | Kilograms
+BALE_WEIGHT_AVERAGE | ??? | Kilograms
+BALE_FLAKES_AVERAGE | ??? | ???
+COUNTER_Bale_Cut | ??? | ???
+COUNTER_Bale_Uncut | ??? | ???
 
 ## Enumeration DRIVE_DIRECTION
 

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -23,6 +23,8 @@ BALE_WEIGHT_AVERAGE | ??? | Kilograms
 BALE_FLAKES_AVERAGE | ??? | ???
 COUNTER_Bale_Cut | ??? | ???
 COUNTER_Bale_Uncut | ??? | ???
+GRAIN_LOSS_Shaker | ??? | Percentage (%)
+GRAIN_LOSS_Rotor | ??? | Percentage (%)
 
 ## Enumeration DRIVE_DIRECTION
 

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -7,7 +7,10 @@ Name | Description | Standard Unit
 ENGINE_HOURS | Total hours of equipment engine | Seconds
 ENGINE_SPEED | Engine speed of equipment | RPM
 DRIVE_DIRECTION | Driving direction of equipment | Enumeration DRIVE_DIRECTION
-
+ENGINE_LOAD | ??? | Percentage (%)
+FUEL_LEVEL | ??? | Percentage (%)
+FUEL_RATE | ??? | Cubic metre per seconds (m³/s)
+MASTER_APPLY | ??? | Enumeration MASTER_APPLY
 
 ## Enumeration DRIVE_DIRECTION
 
@@ -19,3 +22,11 @@ REVERSE | 2
 STAND STILL | 3
 CRUISE CONTROL | 4
 
+## Enumeration MASTER_APPLY
+
+Name | Value
+---- | -----
+OFF | 0
+ON | 1
+ERROR | 2
+NA | 3

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -6,11 +6,11 @@ Name | Description | Standard Unit
 ---- | ----------- | -------------
 ENGINE_HOURS | Total hours of equipment engine | Seconds
 ENGINE_SPEED | Engine speed of equipment | RPM
-DRIVE_DIRECTION | Driving direction of equipment | Enumeration DRIVE_DIRECTION
+DRIVE_DIRECTION | Driving direction of equipment | [Enumeration DRIVE_DIRECTION](#enumeration-drive_direction)
 ENGINE_LOAD | ??? | Percentage (%)
 FUEL_LEVEL | ??? | Percentage (%)
 FUEL_RATE | ??? | Cubic metre per seconds (m³/s)
-MASTER_APPLY | ??? | Enumeration MASTER_APPLY
+MASTER_APPLY | ??? | [Enumeration MASTER_APPLY](#enumeration-master_apply)
 
 ## Enumeration DRIVE_DIRECTION
 

--- a/source/includes/_can-variables.md
+++ b/source/includes/_can-variables.md
@@ -11,6 +11,10 @@ ENGINE_LOAD | ??? | Percentage (%)
 FUEL_LEVEL | ??? | Percentage (%)
 FUEL_RATE | ??? | Cubic metre per seconds (m³/s)
 MASTER_APPLY | ??? | [Enumeration MASTER_APPLY](#enumeration-master_apply)
+MOISTURE_AVERAGE | ??? | Percentage (%)
+YIELD_AVERAGE | ??? | Kilograms per square metre (kg/m²)
+CAPACITY_Average | ??? | Kilograms per second (kg/s)
+TEST_WEIGHT | ??? | Kilograms per cubic metre (kg/m³)
 
 ## Enumeration DRIVE_DIRECTION
 


### PR DESCRIPTION
This PR adds documentation on the available CAN variables on the Equipment API.

[Rendered changes](https://github.com/agco-fuse/documentation/blob/add-doc-can-variables/source/includes/_can-variables.md)