### PR TITLE
Reduces font size on content to fit tables

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -344,6 +344,10 @@ html, body {
     @extend %left-col;
   }
 
+  &>table {
+    font-size: 0.9em;
+  }
+
   &>ul, &>ol {
     padding-left: $main-padding + 15px;
   }


### PR DESCRIPTION
The tables were bleeding on the width, under the dark right sidebar.

Before:
<img width="757" alt="screen shot 2016-04-28 at 2 00 00 pm" src="https://cloud.githubusercontent.com/assets/109474/14894450/15827dec-0d4a-11e6-9d0e-36f33c6c7863.png">

After:
<img width="763" alt="screen shot 2016-04-28 at 1 59 30 pm" src="https://cloud.githubusercontent.com/assets/109474/14894471/2a408094-0d4a-11e6-93dd-9bd4c2636aa8.png">

