### PR TITLE
Updates the link to point to AGCO's landing page

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5,7 +5,7 @@ language_tabs:
   - shell
 
 toc_footers:
-  - <a href='https://agco-fuse.github.io/'>Get in touch for a Developer Key</a>
+  - <a href='https://agco-fuse.github.io/'>Get in touch for Sandbox access</a>
 
 includes:
   - can-variables

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5,7 +5,7 @@ language_tabs:
   - shell
 
 toc_footers:
-  - <a href='#'>Sign Up for a Developer Key</a>
+  - <a href='https://agco-fuse.github.io/'>Get in touch for a Developer Key</a>
 
 includes:
   - can-variables


### PR DESCRIPTION
<img width="228" alt="screen shot 2016-04-28 at 2 13 22 pm" src="https://cloud.githubusercontent.com/assets/109474/14894723/6d64ba38-0d4b-11e6-85b3-8ff566a32c13.png">
