### PR TITLE
Transclude Equipment API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ task :build do
   )
 
   log.info('Updating Swagger references...')
-  documentation_transclusion.transclude(SWAGGER_URL, DOCUMENTATION_ROOT)
+  documentation_transclusion.transclude('telemetry', SWAGGER_URL, DOCUMENTATION_ROOT)
   log.info('Done!')
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ desc 'Update documentation to include Swagger operations and models'
 task :build do
   log.info('Building the documentation...')
 
-  swagger_document_fetcher = SwaggerDocumentFetcher.new
+  swagger_document_fetcher = SwaggerDocumentFetcher.new(log)
   swagger_definition_extractor = SwaggerDefinitionExtractor.new(
     Swagger1DefinitionExtractor.new,
     Swagger2DefinitionExtractor.new

--- a/Rakefile
+++ b/Rakefile
@@ -13,8 +13,12 @@ require './lib/documentation_transclusion.rb'
 log = Logger.new(STDOUT)
 log.level = Logger::INFO
 
-DEFAULT_SWAGGER_URL = 'https://agco-fuse-trackers-dev.herokuapp.com/api-docs/'.freeze
-SWAGGER_URL = ENV.fetch('SWAGGER_URL', DEFAULT_SWAGGER_URL)
+TELEMETRY_DEFAULT_SWAGGER_URL = 'https://agco-fuse-trackers-dev.herokuapp.com/api-docs/'.freeze
+TELEMETRY_SWAGGER_URL = ENV.fetch('TELEMETRY_SWAGGER_URL', TELEMETRY_DEFAULT_SWAGGER_URL)
+
+EQUIPMENT_DEFAULT_SWAGGER_URL = 'https://fuse-equipment-api.herokuapp.com/swagger.json'.freeze
+EQUIPMENT_SWAGGER_URL = ENV.fetch('EQUIPMENT_SWAGGER_URL', EQUIPMENT_DEFAULT_SWAGGER_URL)
+
 DEFAULT_DOCUMENTATION_ROOT = 'source'.freeze
 DOCUMENTATION_ROOT = ENV.fetch('DOCUMENTATION_ROOT', DEFAULT_DOCUMENTATION_ROOT)
 
@@ -38,7 +42,8 @@ task :build do
   )
 
   log.info('Updating Swagger references...')
-  documentation_transclusion.transclude('telemetry', SWAGGER_URL, DOCUMENTATION_ROOT)
+  documentation_transclusion.transclude('telemetry', TELEMETRY_DEFAULT_SWAGGER_URL, DOCUMENTATION_ROOT)
+  documentation_transclusion.transclude('equipments', EQUIPMENT_DEFAULT_SWAGGER_URL, DOCUMENTATION_ROOT)
   log.info('Done!')
 end
 

--- a/lib/documentation_transclusion.rb
+++ b/lib/documentation_transclusion.rb
@@ -11,7 +11,7 @@ class DocumentationTransclusion
     @template_handler = template_handler
   end
 
-  def transclude(swagger_url, documentation_root)
+  def transclude(prefix, swagger_url, documentation_root)
     swagger_documents = @swagger_document_fetcher.fetch(swagger_url)
 
     swagger_documents.each do |document|
@@ -19,7 +19,7 @@ class DocumentationTransclusion
       documentation_filenames = @documentation_finder
                                 .find_all(documentation_root)
 
-      @template_handler.apply(swagger_definition, documentation_filenames)
+      @template_handler.apply(prefix, swagger_definition, documentation_filenames)
     end
   end
 end

--- a/lib/swagger_document_fetcher.rb
+++ b/lib/swagger_document_fetcher.rb
@@ -4,7 +4,13 @@ require 'json'
 # The SwaggerDocumentFetcher class is responsible for
 # retrieving Swagger documents.
 class SwaggerDocumentFetcher
+  def initialize(logger)
+    @logger = logger
+  end
+
+
   def fetch(swagger_url)
+    @logger.info("Fetching Swagger definition on #{swagger_url}")
     documents = []
 
     json = fetch_content_as_json(swagger_url)

--- a/lib/template_handler.rb
+++ b/lib/template_handler.rb
@@ -7,14 +7,14 @@ class TemplateHandler
     @template = template
   end
 
-  def apply(swagger_definition, documentation_filenames)
+  def apply(prefix, swagger_definition, documentation_filenames)
     read_files(documentation_filenames).each do |filename, content|
       swagger_definition.operations.each do |key, value|
-        content.gsub!("[[operation:#{key}]]", @template.render(value))
+        content.gsub!("[[#{prefix}:operation:#{key}]]", @template.render(value))
       end
 
       swagger_definition.models.each do |key, value|
-        content.gsub!("[[model:#{key}]]", @template.render(value))
+        content.gsub!("[[#{prefix}:model:#{key}]]", @template.render(value))
       end
 
       save(filename, content)

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -23,28 +23,28 @@ A brief explanation about brands...
 
 You will notice that the following tag will be replaced by the Brand model.
 
-[[model:Brand]]
+[[telemetry:telemetry:model:Brand]]
 
 ### Getting Brands
 
 A brief explanation on how to get brands...
 
-[[operation:getBrands]]
+[[telemetry:operation:getBrands]]
 
 ### Creating Brands
 
 A brief explanation on how to create new brands...
 
-[[operation:createBrands]]
+[[telemetry:operation:createBrands]]
 
 ### Updating Brands
 
 A brief explanation on how to update brands...
 
-[[operation:updateBrands]]
+[[telemetry:operation:updateBrands]]
 
 ### Deleting Brands
 
 A brief explanation on how to delete brands...
 
-[[operation:deleteBrands]]
+[[telemetry:operation:deleteBrands]]

--- a/spec/documentation_transclusion_spec.rb
+++ b/spec/documentation_transclusion_spec.rb
@@ -118,8 +118,8 @@ EOS
       .and_return(DOCUMENTATION_FILENAMES)
 
     expect(template_handler).to receive(:apply)
-      .with(SWAGGER_DEFINITION, DOCUMENTATION_FILENAMES)
+      .with('prefix', SWAGGER_DEFINITION, DOCUMENTATION_FILENAMES)
 
-    documentation_transclusion.transclude(SWAGGER_URL, DOCUMENTATION_ROOT)
+    documentation_transclusion.transclude('prefix', SWAGGER_URL, DOCUMENTATION_ROOT)
   end
 end

--- a/spec/swagger_document_fetcher_spec.rb
+++ b/spec/swagger_document_fetcher_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require_relative '../lib/swagger_document_fetcher.rb'
 
 describe SwaggerDocumentFetcher do
+  subject { SwaggerDocumentFetcher.new(spy(:logger)) }
+
   it 'should fetch various documents recursively' do
     swagger_url = 'https://agco-fuse-trackers-dev.herokuapp.com/api-docs'
     brands_url = 'https://agco-fuse-trackers-dev.herokuapp.com/api-docs/brands'

--- a/spec/template_handler_spec.rb
+++ b/spec/template_handler_spec.rb
@@ -19,7 +19,7 @@ describe TemplateHandler do
   it 'should apply a template to a documentation file' do
     expect(File).to receive(:read)
       .with('source/doc1.html.md')
-      .and_return('[[operation:getBrands]]\n\n[[model:Brands]]')
+      .and_return('[[prefix:operation:getBrands]]\n\n[[prefix:model:Brands]]')
 
     operation_template = '```json\n{ operation: true }\n```'
     expect(template).to receive(:render)
@@ -42,6 +42,6 @@ describe TemplateHandler do
     swagger_definition = SwaggerDefinition.new(operations, models)
 
     documentation_filenames = ['source/doc1.html.md']
-    subject.apply(swagger_definition, documentation_filenames)
+    subject.apply('prefix', swagger_definition, documentation_filenames)
   end
 end


### PR DESCRIPTION
It would be interesting to include the Swagger definition of the Equipment API.

This PR:

- [x] Changes the fetcher to use a prefix to inform the source when transcluding
- [x] Fetches the Equipment API Swagger definition