### PR TITLE
Refactor the documentation

### DIFF
--- a/source/includes/equipment_api/_equipment.md
+++ b/source/includes/equipment_api/_equipment.md
@@ -20,10 +20,10 @@ You must replace <code>[token]</code> with the token response from the Authentic
 
 ## GET /equipment
 
-> The endpoint information is the following:
+> HTTP 200 Successful:
 
 ```json
-[[equipment:operation:equipment]]
+[[equipment:model:Model 2]]
 ````
 
 This is the endpoint for retrieving the list of equipment.
@@ -34,23 +34,6 @@ On the Equipment API server:
 
 `GET /equipment`.
 
-### Possible responses
-
-Code | Status
----- | ------
-200  | Success
-401  | Unauthorized
-404  | Not Found
-500  | Unhandled Error
-
-## 200 Successful
-
-> The returned model schema is the following:
-
-```json
-[[equipment:model:Model 2]]
-```
-
 When the information is returned with success, a list of equipment will be available.
 
 The list of equipment may contain 0 or more equipment, with the CAN variable
@@ -58,42 +41,12 @@ informations present according to the availability on that specific equipment.
 
 Refer to the [CAN Variables](#can-variables) section to see the possible returned values.
 
-## 401 Unauthorized
-
-> The returned model schema is the following:
-
-```json
-[[equipment:model:Model 3]]
-```
-
-When the authentication token is invalid or expired, the response will return an array of errors, with an item pointing out the status and the response code.
-
-## 404 Not Found
-
-> The returned model schema is the following:
-
-```json
-[[equipment:model:Model 5]]
-```
-
-When the list does not exist, the response will return an array of errors, with an item pointing out the status and the response code.
-
-## 500 Unhandled Error
-
-> The returned model schema is the following:
-
-```json
-[[equipment:model:Model 7]]
-```
-
-When there is an error processing the request, the response will return an array of errors, with an item pointing out the status and the response code.
-
 ## GET /equipment/{id}
 
-> The endpoint information is the following:
+> HTTP 200 Successful
 
 ```json
-[[equipment:operation:equipmentid]]
+[[equipment:model:Model 8]]
 ````
 
 This is the endpoint to receive a single equipment equivalent to the id sent.
@@ -104,32 +57,23 @@ On the Equipment API server:
 
 `GET /equipment/{id}`.
 
-### Possible responses
-
-Code | Status
----- | ------
-200  | Success
-401  | Unauthorized
-404  | Not Found
-500  | Unhandled Error
-
-## 200 Successful
-
-> The returned model schema is the following:
-
-```json
-[[equipment:model:Model 8]]
-```
-
 When the information is returned with success, a single equipment will be available.
 
 The equipment contain the CAN variable informations present according to the availability on that specific equipment.
 
 Refer to the [CAN Variables](#can-variables) section to see the possible returned values.
 
+## Errors
+
+Error Code | Meaning
+---------- | -------
+[401](#401-unauthorized) | [Unauthorized](#401-unauthorized)
+[404](#404-not-found) | [Not Found](#404-not-found)
+[500](#500-internal-server-error) | [Internal Server Error](#500-internal-server-error)
+
 ## 401 Unauthorized
 
-> The returned model schema is the following:
+> 401 Unauthorized
 
 ```json
 [[equipment:model:Model 3]]
@@ -139,7 +83,7 @@ When the authentication token is invalid or expired, the response will return an
 
 ## 404 Not Found
 
-> The returned model schema is the following:
+> 404 Not Found
 
 ```json
 [[equipment:model:Model 5]]
@@ -147,10 +91,12 @@ When the authentication token is invalid or expired, the response will return an
 
 When the list does not exist, the response will return an array of errors, with an item pointing out the status and the response code.
 
-## 500 Unhandled Error
+## 500 Internal Server Error
 
-> The returned model schema is the following:
+> 500 Internal Server Error
 
 ```json
 [[equipment:model:Model 7]]
 ```
+
+When there is an error processing the request, the response will return an array of errors, with an item pointing out the status and the response code.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -8,7 +8,7 @@ toc_footers:
   - <a href='https://agco-fuse.github.io/'>Get in touch for Sandbox access</a>
 
 includes:
-  - equipment
+  - equipment_api/equipment
   - canVariables
 
 search: true


### PR DESCRIPTION
@waldemarnt and I moved the equipment.md file to a equipment_id folder to make it explicit separated from the Telemtry API when we start documenting it.

We also remove the duplicated error responses and removed the JSON with all the possible responses for each endpoint and added the success case instead.

## Before refactor
![doc-before-refactor](https://cloud.githubusercontent.com/assets/4042266/14992738/c5afe2ee-113d-11e6-8dc2-eb7f7e74079c.png)

## After refactor
![doc-after-refactor](https://cloud.githubusercontent.com/assets/4042266/14992737/c58f547a-113d-11e6-8e48-85f35c4a8e3e.png)
