### PR TITLE
Removes unused code tab

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -1,9 +1,6 @@
 ---
 title: API Reference
 
-language_tabs:
-  - json
-
 toc_footers:
   - <a href='https://agco-fuse.github.io/'>Get in touch for Sandbox access</a>
 


### PR DESCRIPTION
I just removed this **json** tab, that we are not using this feature properly.
before
<img width="1137" alt="screen shot 2016-05-04 at 4 43 01 pm" src="https://cloud.githubusercontent.com/assets/5835706/15026935/601b8bf6-1217-11e6-882b-9f23632d77db.png">
after
<img width="1081" alt="screen shot 2016-05-04 at 4 43 12 pm" src="https://cloud.githubusercontent.com/assets/5835706/15026941/667cdde2-1217-11e6-836a-abb60e268bf6.png">
