### PR TITLE
Adds information about the dealership demo project

### DIFF
--- a/source/includes/equipment_api/_equipment.md
+++ b/source/includes/equipment_api/_equipment.md
@@ -4,6 +4,14 @@ The [Equipment API](#equipment-api) is an endpoint with the goal to provide equi
 
 The information about the equipment are retrieved from the Telemetry API and should contain the same values, but on a specific structure.
 
+### Usage Demonstration
+
+An example of the usage of the Equipment API can be observed on the [Dealership Demo Application](https://github.com/agco-fuse/dealership-demo).
+
+This application is written in NodeJS and Angular, demonstrating how to [authenticate](#authentication), retrieve a [list of equipment](#get-equipment) and [single equipment details](#get-equipment-id).
+
+There are more details and instructions on the [application project](https://github.com/agco-fuse/dealership-demo), including how to deploy your own instance of the example.
+
 ## Authentication
 
 To make use of the endpoints, a bearer token is required on the authorization header.


### PR DESCRIPTION
The [Dealerhisp Demo
project](https://github.com/agco-fuse/dealership-demo) is available to
demonstrate how to use the APIs available.

This commit links the documentation to it, given a little context of
what the project is and what is expected to be found when accessing the
README for the example.

---

[Rendered text changes](https://github.com/agco-fuse/documentation/blob/include-dealership-demo-on-documentation/source/includes/equipment_api/_equipment.md)

Screenshot rendered locally:
<img width="1280" alt="screen shot 2016-05-16 at 10 47 32 am" src="https://cloud.githubusercontent.com/assets/109474/15291429/2faf252c-1b54-11e6-978b-fd83c1f34580.png">
