### PR TITLE
Adds an introduction to the API in general

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -19,4 +19,22 @@ search: true
 
 # Introduction
 
-A brief introduction...
+Welcome to the AGCO Fuse API documentation. Here you will find more information
+about the various endpoints available to access data from our platform, like
+sample responses and status codes.
+
+All the endpoints are developed with
+[REST](https://en.wikipedia.org/wiki/Representational_state_transfer) in mind,
+letting you programmatic access the information from a mobile application,
+another webserver for processing information and displaying it later,
+applications on any programming language and so on.
+
+The responses of the endpoints are sent in [JSON](http://www.json.org/) format
+for ubiquitous access, being a webserver, mobile or web browser application.
+
+Each of the enpoints are described with more details on the following sections.
+Use the Table Of Contents on the left sidebar to navigate to a specific service
+for further information.
+
+To gain credential access to the APIs and learn how to authenticate, there is a
+[Getting Started](#getting-started) section for you.


### PR DESCRIPTION
This introduction has the objective to inform the used format of the
endpoints, as well as the information access infrastructure, in this
case REST.

---
[Rendered text changes](https://github.com/agco-fuse/documentation/blob/introduce-rest-concepts/source/index.html.md)

Screenshot:
<img width="1280" alt="screen shot 2016-05-16 at 12 26 27 pm" src="https://cloud.githubusercontent.com/assets/109474/15294161/7d5c3474-1b61-11e6-8328-e3ffd861dfc4.png">
