### PR TITLE
Expands the introductory paragraph on Telemetry API

### DIFF
--- a/source/includes/telemetry_api/_introduction.md
+++ b/source/includes/telemetry_api/_introduction.md
@@ -2,6 +2,27 @@
 
 ## Introduction
 
-This is the API that contain the equipment and all telemetry data for each equipment the user own.
+The Telemetry API provides access to data about each equipment the user owns.
+The information queried provides a rich inspection of the telemetry data sent
+to AGCO's platform.
 
-Is possible get [equipment](#get-equipment), trackingPoint, trackingData with [canVariables](#can-variables).
+You are able to retrieve information about equipment,
+[equipment](#get-equipment20), [equipment's duty state](#get-duties), [tracking
+data](#get-trackingdata), or [tracking point](#get-trackingpoints) for example.
+
+This service is built on top of our open source
+[elastic-harversterjs](https://github.com/agco/elastic-harvesterjs) library,
+enabling advanced queries to be sent so you can have precise access to
+information available on the platform.
+
+The endpoints on this service implement [AGCO's JSON API
+Profile](https://github.com/agco/agco-json-api-profiles) extensions, which let
+you
+[filter](https://github.com/agco/agco-json-api-profiles/blob/master/public/filtering-profile.md),
+[request change
+events](https://github.com/agco/agco-json-api-profiles/blob/master/public/change-events-profile.md),
+and
+[search](https://github.com/agco/agco-json-api-profiles/blob/master/public/search-profile.md)
+the information available.
+
+For further information on each endpoint, as examples and status code, see the following sections.


### PR DESCRIPTION
This commit adds more context around the Telemetry API service. It
informs that it is backed by [elastic-harvestjs](https://github.com/agco/elastic-harvesterjs), which lets you manipulate the information sent back with queries to return precise information.

It also indicates the documentation on [ACGO's JSON API Profiles](https://github.com/agco/agco-json-api-profiles) to the reader, so they have more information on the extra possibilities to manipulate the returned information.

---
[Rendered text changes](https://github.com/agco-fuse/documentation/blob/explain-about-harvesterjs/source/includes/telemetry_api/_introduction.md)

Screenshot:
<img width="1279" alt="screen shot 2016-05-16 at 2 12 49 pm" src="https://cloud.githubusercontent.com/assets/109474/15297423/6b1f3c48-1b70-11e6-8587-9c268e45ede2.png">


