### PR TITLE
Prevents breaking words between letters

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -100,6 +100,6 @@ $search-box-border-color: #610b18;
 // These settings are probably best left alone.
 
 %break-words {
-    word-break: break-all;
+    word-break: normal;
     hyphens: auto;
 }


### PR DESCRIPTION
When wrapping some words with code quotes like `this`, the words would
break between letters, and not on word boundaries.

This commit reverts this behaviour to use the normal word break style.

---
Screenshot before:
<img width="524" alt="screen shot 2016-05-16 at 7 31 00 pm" src="https://cloud.githubusercontent.com/assets/109474/15305974/235aab72-1b9d-11e6-830c-e7a48c956072.png">

Screenshot after:
<img width="533" alt="screen shot 2016-05-16 at 7 30 53 pm" src="https://cloud.githubusercontent.com/assets/109474/15305989/3f0aa2fa-1b9d-11e6-9d15-2d6180f3f7c9.png">
