### PR TITLE
Fixes images sizes

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -454,10 +454,6 @@ html, body {
     margin-top: 0;
   }
 
-  img {
-    max-width: 525px;
-  }
-
   code {
     background-color: rgba(0,0,0,0.05);
     padding: 3px;
@@ -525,6 +521,10 @@ html, body {
 // This is all the stuff that appears in the right half of the page
 
 .content {
+  &>img {
+    max-width: 50%;
+  }
+
   pre, blockquote {
     background-color: $code-bg;
     color: #fff;
@@ -628,4 +628,12 @@ html, body {
 
 .highlight, .highlight .w {
   background-color: $code-bg;
+}
+
+p {
+  &>img {
+    max-width: 80%;
+    display: block;
+    margin: 0 auto;
+  }
 }


### PR DESCRIPTION
@jeffhsta and I fixed image sizes inside container block and banner to fit the screen.

Before:
<img width="713" alt="screen shot 2016-05-17 at 11 47 47 am" src="https://cloud.githubusercontent.com/assets/5835706/15326670/3ef2691e-1c25-11e6-83cd-6641b60de56b.png">
<img width="798" alt="screen shot 2016-05-17 at 11 47 57 am" src="https://cloud.githubusercontent.com/assets/5835706/15326669/3eed02d0-1c25-11e6-99ef-91174a96fe11.png">
After:
<img width="659" alt="screen shot 2016-05-17 at 11 48 28 am" src="https://cloud.githubusercontent.com/assets/5835706/15326689/50f299f4-1c25-11e6-9195-c83d7f072780.png">
<img width="621" alt="screen shot 2016-05-17 at 11 48 35 am" src="https://cloud.githubusercontent.com/assets/5835706/15326688/50ef998e-1c25-11e6-9599-8ce8d0655ee5.png">
