### PR TITLE
Includes references to JSON API

### DIFF
--- a/source/includes/equipment_api/_equipment.md
+++ b/source/includes/equipment_api/_equipment.md
@@ -4,6 +4,9 @@ The [Equipment API](#equipment-api) is an endpoint with the goal to provide equi
 
 The information about the equipment are retrieved from the Telemetry API and should contain the same values, but on a specific structure.
 
+The structure of the response of the endpoints follow the [JSON API 1.0](http://jsonapi.org/format/1.0/) specification.
+JSON API is a specification for how a client should request that resources be fetched or modified, and how a server should respond to those requests.
+
 ### Usage Demonstration
 
 An example of the usage of the Equipment API can be observed on the [Dealership Demo Application](https://github.com/agco-fuse/dealership-demo).

--- a/source/includes/equipment_api/_equipment.md
+++ b/source/includes/equipment_api/_equipment.md
@@ -4,8 +4,8 @@ The [Equipment API](#equipment-api) is an endpoint with the goal to provide equi
 
 The information about the equipment are retrieved from the Telemetry API and should contain the same values, but on a specific structure.
 
-The structure of the response of the endpoints follow the [JSON API 1.0](http://jsonapi.org/format/1.0/) specification.
-JSON API is a specification for how a client should request that resources be fetched or modified, and how a server should respond to those requests.
+The structure of endpoint responses follow the [JSON API 1.0](http://jsonapi.org/format/1.0/) specification.
+JSON API is a specification concerning how a client should request that resources to be fetched or modified, and how a server should respond to those requests.
 
 ### Usage Demonstration
 

--- a/source/includes/telemetry_api/_introduction.md
+++ b/source/includes/telemetry_api/_introduction.md
@@ -15,6 +15,9 @@ This service is built on top of our open source
 advanced queries to be sent so you can have precise access to information
 available on the platform.
 
+The responses follow the [JSON API](http://jsonapi.org/) on version 0.8.
+This normalizes how to request and parse the responses on the service.
+
 The endpoints on this service implement [AGCO's JSON API
 Profile](https://github.com/agco/agco-json-api-profiles) extensions, which let
 you

--- a/source/includes/telemetry_api/_introduction.md
+++ b/source/includes/telemetry_api/_introduction.md
@@ -15,7 +15,7 @@ This service is built on top of our open source
 advanced queries to be sent so you can have precise access to information
 available on the platform.
 
-The responses follow the [JSON API](http://jsonapi.org/) on version 0.8.
+The responses follow the [JSON API](http://jsonapi.org/) version 0.8.
 This normalizes how to request and parse the responses on the service.
 
 The endpoints on this service implement [AGCO's JSON API


### PR DESCRIPTION
This commit adds a link to the documentation of JSON API 1.0 on
Equipment API, so others can look for clients and more specificities on
how to interact with our API.

There was no canonical reference to the JSON API 0.8 spec used on
Telemetry API, so we just refer to the spec, as there is a user forum
for support further questions on the spec's page.

---

[Rendered Equipment API changes](https://github.com/agco-fuse/documentation/blob/d9775d5f8dd00f509cea0ce9340fa9a4a029a925/source/includes/equipment_api/_equipment.md)

[Rendered Telemetry API changes](https://github.com/agco-fuse/documentation/blob/d9775d5f8dd00f509cea0ce9340fa9a4a029a925/source/includes/telemetry_api/_introduction.md)