### PR TITLE
Use tags to display content according to reader interest

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,3 +1,5 @@
+require_relative './extended_lexer_tags.rb'
+
 # Markdown
 set :markdown_engine, :redcarpet
 set :markdown,

--- a/config.rb
+++ b/config.rb
@@ -1,4 +1,4 @@
-require_relative './extended_lexer_tags.rb'
+require File.expand_path('../extended_lexer_tags.rb', __FILE__)
 
 # Markdown
 set :markdown_engine, :redcarpet

--- a/extended_lexer_tags.rb
+++ b/extended_lexer_tags.rb
@@ -1,0 +1,13 @@
+require 'rouge'
+
+module Rouge
+  module Lexers
+    class Schema < ::Rouge::Lexers::JSON
+      tag 'schema'
+    end
+
+    class Curl < ::Rouge::Lexers::Shell
+      tag 'curl'
+    end
+  end
+end

--- a/source/includes/equipment_api/_equipment.md
+++ b/source/includes/equipment_api/_equipment.md
@@ -40,9 +40,17 @@ You must replace <code>[token]</code> with the token response from the Authentic
 
 ## GET /equipment
 
-> HTTP 200 Successful Response schema:
+<blockquote class='lang-specific curl'><p>Example of using curl to request a list of equipment</p></blockquote>
 
-```json
+```curl
+curl -X GET \
+  --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+  "https://fuse-equipment-api.herokuapp.com/equipment?limit=1&offset=0"
+```
+
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response schema:</p></blockquote>
+
+```schema
 [[equipment:model:equipmentData]]
 ```
 
@@ -73,9 +81,17 @@ Refer to the [CAN Variables](#can-variables) section to see the possible returne
 
 ## GET /equipment/{id}
 
-> HTTP 200 Successful Response schema
+<blockquote class='lang-specific curl'><p>Example of using curl to request details of an equipment</p></blockquote>
 
-```json
+```curl
+curl -X GET \
+  --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+  "https://fuse-equipment-api.herokuapp.com/equipment/{id of the equipment}"
+```
+
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response schema:</p></blockquote>
+
+```schema
 [[equipment:model:anEquipmentData]]
 ```
 
@@ -112,9 +128,9 @@ Error Code                        | Meaning
 
 ## 401 Unauthorized
 
-> 401 Unauthorized
+<blockquote class='lang-specific schema'><p>HTTP 401 Unauthorized Response schema:</p></blockquote>
 
-```json
+```schema
 [[equipment:model:401]]
 ```
 
@@ -122,9 +138,9 @@ When the authentication token is invalid or expired, the response will return an
 
 ## 404 Not Found
 
-> 404 Not Found
+<blockquote class='lang-specific schema'><p>HTTP 404 Not Found Response schema:</p></blockquote>
 
-```json
+```schema
 [[equipment:model:404]]
 ```
 
@@ -132,9 +148,9 @@ When the list does not exist, the response will return an array of errors, with 
 
 ## 500 Internal Server Error
 
-> 500 Internal Server Error
+<blockquote class='lang-specific schema'><p>HTTP 500 Internal Server Error Response schema:</p></blockquote>
 
-```json
+```schema
 [[equipment:model:500]]
 ```
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -4,6 +4,10 @@ title: API Reference
 toc_footers:
   - <a href='https://agco-fuse.github.io/'>Get in touch for Sandbox access</a>
 
+language_tabs:
+  - curl
+  - schema
+
 includes:
   - external_user_workflow/workflow
   - equipment_api/equipment


### PR DESCRIPTION
We would like to have a curl example and the schema for the response on the Equipment API.

The schema itself tend to be large and add a bit of visual noise on the page. We would like to let the user only see the schema when it desires, hiding with the `language_tabs` feature of Slate.

This PR let's use use some custom tag to choose which content will be displayed. It does not impact other content display, like `json` or `shell` that are present in other sections, so we can have content there that is not filtered by the tabs.

----

Local screenshot showing the same section with different tabs selected:

<img width="1280" alt="screen shot 2016-05-18 at 4 00 47 pm" src="https://cloud.githubusercontent.com/assets/109474/15371436/c139275e-1d11-11e6-883f-2c0846a4a3c8.png">
<img width="1280" alt="screen shot 2016-05-18 at 4 00 42 pm" src="https://cloud.githubusercontent.com/assets/109474/15371437/c13932b2-1d11-11e6-8c30-50c9148a1237.png">

