### PR TITLE
Adapt documentation to right tabs

### DIFF
--- a/source/includes/external_user_workflow/_workflow.md
+++ b/source/includes/external_user_workflow/_workflow.md
@@ -58,9 +58,9 @@ access token like the `authentication response` example in the right column.
 
 For more details about OAuth2 access the [http://oauth.net/2/](http://oauth.net/2/)
 
-> `curl` example of OAuth2 authentication:
+<blockquote class='lang-specific curl'><p>`curl` example of OAuth2 authentication:</p></blockquote>
 
-```shell
+```curl
 curl -k -X "POST"\
     "https://aaat.agcocorp.com/auth/oauth2/access_token?realm=/dealers"\
     --data-urlencode "username=YOUR_USERNAME"\
@@ -71,7 +71,7 @@ curl -k -X "POST"\
     --data-urlencode "grant_type=password"
 ```
 
-> HTTP 200 authentication response example:
+<blockquote class='lang-specific json'><p>HTTP 200 authentication response example:</p></blockquote>
 
 ```json
 {
@@ -95,9 +95,9 @@ Field           | Description
 
 ## How permissions are handled
 
-> Example of how to get models from Telemetry API using OAuth2 authentication:
+<blockquote class='lang-specific curl'><p>Example of how to get models from Telemetry API using OAuth2 authentication:</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     -H "Authorization: Bearer YOUR_ACCESS_TOKEN"\
     "https://agco-fuse-trackers-sandbox.herokuapp.com/models"

--- a/source/includes/telemetry_api/_duties.md
+++ b/source/includes/telemetry_api/_duties.md
@@ -17,17 +17,17 @@ Possible duty states are:
 
 ## GET /duties
 
-> curl example to get a list of duties:
+<blockquote class='lang-specific curl'><p>curl example to get a list of duties:</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/duties"
 ```
 
-> HTTP 200 Successful Response Schema:
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response Schema:</p></blockquote>
 
-```json
+```schema
 [[telemetry:operation:getDuty]]
 ```
 
@@ -45,25 +45,25 @@ There are some [parameters](#duties-request-parameters) that can be sent to `GET
 
 ## GET /duties/{id}
 
-> curl example to get one duties by id
+<blockquote class='lang-specific curl'><p>curl example to get one duties by id</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/duties/{DUTY ID}"
 ```
 
-> curl example to get two duties by id
+<blockquote class='lang-specific curl'><p>curl example to get two duties by id</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?id={DUTY ID 1},{DUTY ID 2}"
 ```
 
-> HTTP 200 Successful Response Schema:
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response Schema:</p></blockquote>
 
-```json
+```schema
 [[telemetry:operation:getDuty]]
 ```
 
@@ -81,9 +81,9 @@ There are some [parameters](#duties-request-parameters) that can be sent to `GET
 
 ## Duties request parameters
 
-> curl example to get a list of tracking points sending parameters:
+<blockquote class='lang-specific curl'><p>curl example to get a list of tracking points sending parameters:</p></blockquote>
 
-```shell
+```curl
 curl -X GET --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
 "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?\
 status={DUTY VALUE}&\

--- a/source/includes/telemetry_api/_equipment.md
+++ b/source/includes/telemetry_api/_equipment.md
@@ -12,17 +12,17 @@ You will only access equipment your access token allows.
 
 ## GET /equipment
 
-> curl example to get a list of equipment:
+<blockquote class='lang-specific curl'><p>curl example to get a list of equipment:</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/equipment"
 ```
 
-> HTTP 200 Successful Response Schema:
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response Schema:</p></blockquote>
 
-```json
+```schema
 [[telemetry:operation:getEquipment]]
 ```
 
@@ -42,25 +42,25 @@ There are some [parameters](#equipment-request-parameters) that can be sent to `
 
 ## GET /equipment/{id}
 
-> curl example to get one equipment by id
+<blockquote class='lang-specific curl'><p>curl example to get one equipment by id</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/equipment/{EQUIPMENT ID}"
 ```
 
-> curl example to get two equipment by id
+<blockquote class='lang-specific curl'><p>curl example to get two equipment by id</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/equipment?id={EQUIPMENT ID 1},{EQUIPMENT ID 2}"
 ```
 
-> HTTP 200 Successful Response Schema:
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response Schema:</p></blockquote>
 
-```json
+```schema
 [[telemetry:operation:getEquipment]]
 ```
 
@@ -80,9 +80,9 @@ There are some parameters that can be sent to `GET /equipment/{id}` to get more 
 
 ## Equipment request parameters
 
-> curl example to get a list of equipment sending parameters:
+<blockquote class='lang-specific curl'><p>curl example to get a list of equipment sending parameters:</p></blockquote>
 
-```shell
+```curl
 curl -X GET --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
 "https://agco-fuse-trackers-sandbox.herokuapp.com/equipment?&\
 include=model,dealer,manufacturingModel&\
@@ -98,7 +98,6 @@ The parameters below are optional:
  - **manufacturingModel**: The manufacturing model code.
 - **offset**: Defines from each index start the list (the first index is 0).
 - **limit**: Defines max number of equipment on the response
-
 
 ## Equipment ownership
 

--- a/source/includes/telemetry_api/_trackingData.md
+++ b/source/includes/telemetry_api/_trackingData.md
@@ -4,17 +4,17 @@ Manages tracking data.
 
 ## GET /trackingData
 
-> curl example to get a list of tracking data:
+<blockquote class='lang-specific curl'><p>curl example to get a list of tracking data:</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData"
 ```
 
-> HTTP 200 Successful Response Schema:
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response Schema:</p></blockquote>
 
-```json
+```schema
 [[telemetry:operation:getTrackingData]]
 ```
 
@@ -32,25 +32,25 @@ There are some [parameters](#tracking-data-request-parameters) that can be sent 
 
 ## GET /trackingData/{id}
 
-> curl example to get one tracking data by id
+<blockquote class='lang-specific curl'><p>curl example to get one tracking data by id</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/{TRACKING DATA ID}"
 ```
 
-> curl example to get two tracking data by id
+<blockquote class='lang-specific curl'><p>curl example to get two tracking data by id</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?id={TRACKING DATA ID 1},{TRACKING DATA ID 2}"
 ```
 
-> HTTP 200 Successful Response Schema:
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response Schema:</p></blockquote>
 
-```json
+```schema
 [[telemetry:operation:getTrackingData]]
 ```
 
@@ -68,25 +68,25 @@ There are some parameters that can be sent to `GET /trackingData/{id}` to get mo
 
 ## GET /trackingData/search
 
-> curl example to get more information from trackingData:
+<blockquote class='lang-specific curl'><p>curl example to get more information from trackingData:</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint"
 ```
 
-> curl example to get ENGINE_HOURS as an associated CAN variable:
+<blockquote class='lang-specific curl'><p>curl example to get ENGINE_HOURS as an associated CAN variable:</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?links.canVariable=ENGINE_HOURS"
 ```
 
-> curl example to get aggregated trackingData information:
+<blockquote class='lang-specific curl'><p>curl example to get aggregated trackingData information:</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint&\
@@ -138,9 +138,9 @@ further information about aggregations operators
 
 ## Tracking data request parameters
 
-> curl example to get a list of tracking data sending parameters:
+<blockquote class='lang-specific curl'><p>curl example to get a list of tracking data sending parameters:</p></blockquote>
 
-```shell
+```curl
 curl -X GET --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
 "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?\
 externalId={EXTERNAL TRACKING DATA ID}&\

--- a/source/includes/telemetry_api/_trackingPoints.md
+++ b/source/includes/telemetry_api/_trackingPoints.md
@@ -4,17 +4,17 @@ Manages tracking points.
 
 ## GET /trackingPoints
 
-> curl example to get a list of tracking points:
+<blockquote class='lang-specific curl'><p>curl example to get a list of tracking points:</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingPoints"
 ```
 
-> HTTP 200 Successful Response Schema:
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response Schema:</p></blockquote>
 
-```json
+```schema
 [[telemetry:operation:getTrackingPoint]]
 ```
 
@@ -32,25 +32,25 @@ There are some [parameters](#tracking-points-request-parameters) that can be sen
 
 ## GET /trackingPoints/{id}
 
-> curl example to get one tracking points by id
+<blockquote class='lang-specific curl'><p>curl example to get one tracking points by id</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingPoints/{TRACKING POINT ID}"
 ```
 
-> curl example to get two tracking points by id
+<blockquote class='lang-specific curl'><p>curl example to get two tracking points by id</p></blockquote>
 
-```shell
+```curl
 curl -X GET \
     --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?id={TRACKING POINT ID 1},{TRACKING POINT ID 2}"
 ```
 
-> HTTP 200 Successful Response Schema:
+<blockquote class='lang-specific schema'><p>HTTP 200 Successful Response Schema:</p></blockquote>
 
-```json
+```schema
 [[telemetry:operation:getTrackingPoint]]
 ```
 
@@ -69,9 +69,9 @@ There are some [parameters](#tracking-points-request-parameters) that can be sen
 
 ## Tracking points request parameters
 
-> curl example to get a list of tracking points sending parameters:
+<blockquote class='lang-specific curl'><p>curl example to get a list of tracking points sending parameters:</p></blockquote>
 
-```shell
+```curl
 curl -X GET --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
 "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?\
 deviceId={DEVICE ID}&\


### PR DESCRIPTION
Adapted the curl examples and schemas to the tabs on documentation right panel.

It now looks like this:

**Curl tab selected:**
![screenshot from 2016-05-20 13-55-56](https://cloud.githubusercontent.com/assets/4042266/15435469/b6bcdd70-1e92-11e6-8c33-b9f2575ba17d.png)

**Schema tab selected:**
![screenshot from 2016-05-20 13-56-24](https://cloud.githubusercontent.com/assets/4042266/15435470/b6bf553c-1e92-11e6-9d30-0de89c048d13.png)
