### PR TITLE
Adjust CAN variables table ('Standard Unit' col)

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -425,7 +425,11 @@ html, body {
     }
 
     td {
-      padding: 10px;
+      padding: 8px;
+      word-break: break-word;
+      width: 110px;
+      font-size: 0.8em;
+      border-bottom: 1px dotted #ccc;
     }
 
     tr:last-child {


### PR DESCRIPTION
'Standard Unit' column was broke, as shown in the screenshot below
<img width="1277" alt="screen shot 2016-05-23 at 3 43 36 pm" src="https://cloud.githubusercontent.com/assets/272868/15480686/3dde86e8-20fd-11e6-818f-a8f89c715b04.png">

Adding some css style code, adjust the referred column, as shown in the screenshot below:
<img width="1279" alt="screen shot 2016-05-23 at 3 46 00 pm" src="https://cloud.githubusercontent.com/assets/272868/15480736/806b30d8-20fd-11e6-885b-00c7b8f8c4fc.png">
