### PR TITLE
Removing special characters around Bearer tokens

### DIFF
--- a/source/includes/equipment_api/_equipment.md
+++ b/source/includes/equipment_api/_equipment.md
@@ -50,7 +50,7 @@ You must replace <code>[token]</code> with the token response from the Authentic
 
 ```curl
 curl -X GET \
-  --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+  --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   "https://fuse-equipment-api-sandbox.herokuapp.com/equipment?limit=1&offset=0"
 ```
 
@@ -91,7 +91,7 @@ Refer to the [CAN Variables](#can-variables) section to see the possible returne
 
 ```curl
 curl -X GET \
-  --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+  --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
   "https://fuse-equipment-api-sandbox.herokuapp.com/equipment/{id of the equipment}"
 ```
 

--- a/source/includes/telemetry_api/_duties.md
+++ b/source/includes/telemetry_api/_duties.md
@@ -21,7 +21,7 @@ Possible duty states are:
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/duties"
 ```
 
@@ -49,7 +49,7 @@ There are some [parameters](#duties-request-parameters) that can be sent to `GET
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/duties/{DUTY ID}"
 ```
 
@@ -57,7 +57,7 @@ curl -X GET \
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?id={DUTY ID 1},{DUTY ID 2}"
 ```
 
@@ -84,7 +84,7 @@ There are some [parameters](#duties-request-parameters) that can be sent to `GET
 <blockquote class='lang-specific curl'><p>curl example to get a list of tracking points sending parameters:</p></blockquote>
 
 ```curl
-curl -X GET --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+curl -X GET --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?\
 status={DUTY VALUE}&\
 limit=10&\

--- a/source/includes/telemetry_api/_equipment.md
+++ b/source/includes/telemetry_api/_equipment.md
@@ -16,7 +16,7 @@ You will only access equipment your access token allows.
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/equipment"
 ```
 
@@ -46,7 +46,7 @@ There are some [parameters](#equipment-request-parameters) that can be sent to `
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/equipment/{EQUIPMENT ID}"
 ```
 
@@ -54,7 +54,7 @@ curl -X GET \
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/equipment?id={EQUIPMENT ID 1},{EQUIPMENT ID 2}"
 ```
 
@@ -83,7 +83,7 @@ There are some parameters that can be sent to `GET /equipment/{id}` to get more 
 <blockquote class='lang-specific curl'><p>curl example to get a list of equipment sending parameters:</p></blockquote>
 
 ```curl
-curl -X GET --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+curl -X GET --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 "https://agco-fuse-trackers-sandbox.herokuapp.com/equipment?&\
 include=model,dealer,manufacturingModel&\
 limit=10&\

--- a/source/includes/telemetry_api/_trackingData.md
+++ b/source/includes/telemetry_api/_trackingData.md
@@ -8,7 +8,7 @@ Manages tracking data.
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData"
 ```
 
@@ -36,7 +36,7 @@ There are some [parameters](#tracking-data-request-parameters) that can be sent 
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/{TRACKING DATA ID}"
 ```
 
@@ -44,7 +44,7 @@ curl -X GET \
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?id={TRACKING DATA ID 1},{TRACKING DATA ID 2}"
 ```
 
@@ -72,7 +72,7 @@ There are some parameters that can be sent to `GET /trackingData/{id}` to get mo
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint"
 ```
 
@@ -80,7 +80,7 @@ curl -X GET \
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?links.canVariable=ENGINE_HOURS"
 ```
 
@@ -88,7 +88,7 @@ curl -X GET \
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData/search?include=trackingPoint&\
 aggregations=equipmentAgg&\
 equipmentAgg.property=links.trackingPoint.equipment.id"
@@ -143,7 +143,7 @@ further information about aggregations operators
 <blockquote class='lang-specific curl'><p>curl example to get a list of tracking data sending parameters:</p></blockquote>
 
 ```curl
-curl -X GET --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+curl -X GET --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?\
 externalId={EXTERNAL TRACKING DATA ID}&\
 raw={RAW VALUE}&\

--- a/source/includes/telemetry_api/_trackingPoints.md
+++ b/source/includes/telemetry_api/_trackingPoints.md
@@ -8,7 +8,7 @@ Manages tracking points.
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingPoints"
 ```
 
@@ -36,7 +36,7 @@ There are some [parameters](#tracking-points-request-parameters) that can be sen
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingPoints/{TRACKING POINT ID}"
 ```
 
@@ -44,7 +44,7 @@ curl -X GET \
 
 ```curl
 curl -X GET \
-    --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+    --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
     "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?id={TRACKING POINT ID 1},{TRACKING POINT ID 2}"
 ```
 
@@ -72,7 +72,7 @@ There are some [parameters](#tracking-points-request-parameters) that can be sen
 <blockquote class='lang-specific curl'><p>curl example to get a list of tracking points sending parameters:</p></blockquote>
 
 ```curl
-curl -X GET --header "Authorization: Bearer {YOUR ACCESS TOKEN}" \
+curl -X GET --header "Authorization: Bearer YOUR_ACCESS_TOKEN" \
 "https://agco-fuse-trackers-sandbox.herokuapp.com/trackingData?\
 deviceId={DEVICE ID}&\
 head={HEAD VALUE}&\


### PR DESCRIPTION
Nowadays we are wrapping the phrase 'YOUR ACCESS TOKEN' with '{'
and '}'.

While onboarding new users, they mentioned that their first impression
was that they would need to wrap their actual Bearer tokens with '{}'.

This commit removes these characters in order to avoid this sort of
miscommunication.